### PR TITLE
Connect components to webkit_components discourse plugin

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,8 +19,8 @@
       />
       <People
         v-if="section.type == 'people'"
-        :users="category.users"
         :custom="getSectionData('people')"
+        :baseUrl="baseUrl"
       />
       <Topics
         v-if="section.type == 'topics'"

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,9 +83,14 @@ export default {
     },
     applyCategory({ data }) {
       this.categories = data;
-      this.category = data.find(({ id }) => id === parseInt(this.data.category));
-      axios.get(`${this.baseUrl}/webkit_components/topics.json?categories=${this.category.slug}`)
-        .then(({ data }) => (this.topics = data))
+      this.category = data.find(
+        ({ id }) => id === parseInt(this.data.category)
+      );
+      axios
+        .get(
+          `${this.baseUrl}/webkit_components/topics.json?categories=${this.category.slug}`
+        )
+        .then(({ data }) => (this.topics = data));
     },
     getCategoryMetadata(id) {
       return this.categories.find(category => category.id === id) || {};

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,12 +15,12 @@
       <Events
         v-if="section.type == 'events'"
         :custom="getSectionData('events')"
-        :baseUrl="baseUrl"
+        :baseUrl="data.baseUrl"
       />
       <People
         v-if="section.type == 'people'"
         :custom="getSectionData('people')"
-        :baseUrl="baseUrl"
+        :baseUrl="data.baseUrl"
       />
       <Topics
         v-if="section.type == 'topics'"
@@ -55,7 +55,6 @@ export default {
   name: "home",
   data() {
     return {
-      baseUrl: "http://localhost:3000",
       data,
       category: { users: [] },
       categories: [],
@@ -78,7 +77,7 @@ export default {
   methods: {
     fetchData() {
       axios
-        .get(`${this.baseUrl}/webkit_components/categories.json`)
+        .get(`${this.data.baseUrl}/webkit_components/categories.json`)
         .then(this.applyCategory);
     },
     applyCategory({ data }) {
@@ -88,7 +87,7 @@ export default {
       );
       axios
         .get(
-          `${this.baseUrl}/webkit_components/topics.json?categories=${this.category.slug}`
+          `${this.data.baseUrl}/webkit_components/topics.json?categories=${this.category.slug}`
         )
         .then(({ data }) => (this.topics = data));
     },

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -18,19 +18,19 @@
     <div class="wrapper md:wrapper-md" :class="view">
       <div class="list md:list-md" v-if="view == 'list'">
         <div
-          v-for="item in data_reverse"
-          :key="item.timestamp"
-          :class="{ active: item.timestamp == selected.timestamp }"
+          v-for="item in data"
+          :key="item.id"
+          :class="{ active: item.id === selected.id }"
           class="list_item"
-          @click="filterEvent(item.date)"
+          @click="filterEvent(item)"
         >
-          <p class="font-bold">{{ item.timestamp | formatDate }}</p>
+          <p class="font-bold">{{ item.event.start | formatDate }}</p>
           <h4>{{ item.title }}</h4>
         </div>
       </div>
       <div
         class="calendar_container md:calendar_container-md"
-        :class="{ active: minimize == true }"
+        :class="{ active: minimize }"
         v-if="view == 'calendar'"
       >
         <div class="calendar_nav md:calendar_nav-md" v-if="selected">
@@ -38,31 +38,28 @@
           <h3 @click="toggle">
             <span class="triangle md:hidden"></span>
             <span v-if="$mq == 'sm'">{{
-              selected.timestamp | formatDate
+              selected.event.start | formatDate
             }}</span>
-            <span v-else>{{ month | formatMonth }}</span>
+            <span v-else>{{ selected.event.start | formatMonth }}</span>
           </h3>
           <button class="arrow right" @click="next"></button>
         </div>
         <FunctionalCalendar
           v-if="data"
           ref="Calendar"
-          @choseDay="selectEvent"
-          :dayNames="dayNames"
-          :date-format="'dd-mm-yyyy'"
-          :change-month-function="true"
-          :change-year-function="true"
-          :marked-dates="data"
-          :isDatePicker="true"
-        >
-        </FunctionalCalendar>
+          date-format="dd-mm-yyyy"
+          @chose-day="selectEvent"
+          :day-names="dayNames"
+          :marked-dates="dates"
+          :is-date-picker="true"
+        />
       </div>
       <div v-if="selected" class="selected_event md:selected_event-md">
         <a class="event_title" :href="selected.url" target="_blank">
           <h3>{{ selected.title }}</h3>
           <div class="event_info" v-if="selected.time !== '00:00'">
             <span class="time">{{ selected.time }}</span>
-            <span class="timezone">{{ selected.timezone }}</span>
+            <span class="timezone">{{ selected.event.timezone }}</span>
           </div>
         </a>
         <div class="event_excerpt">
@@ -72,7 +69,7 @@
         </div>
         <div class="event_footer">
           Added on {{ selected.created_at | formatDate }} by
-          {{ selected.posted_by }}
+          {{ selected.author.name || selected.author.username }}
         </div>
       </div>
     </div>
@@ -85,14 +82,13 @@ import { FunctionalCalendar } from "vue-functional-calendar";
 import moment from "moment";
 
 export default {
-  props: ["custom"],
+  props: ["custom", "baseUrl"],
   data() {
     return {
       calendar: null,
       data: null,
-      months_data: null,
+      months: null,
       view: "calendar",
-      raw_data: null,
       selected: null,
       month: null,
       minimize: true,
@@ -106,203 +102,86 @@ export default {
     toggleView(view) {
       this.view = view;
       if (view == "calendar") {
-        var date = this.formatDate(this.selected.timestamp);
-
-        this.$nextTick(() => {
-          this.selectDate(date);
-          this.month =
-            "01-" +
-            this.selected.timestamp.substring(5, 7) +
-            "-" +
-            this.selected.timestamp.substring(0, 4);
-        });
+        this.selectDate();
       }
     },
     selectEvent(day) {
-      this.filterEvent(day.date);
+      this.filterEvent(day);
       this.toggle();
     },
-    filterEvent(date) {
-      var event = this.data.filter(function(obj) {
-        return obj.date == date;
-      });
-      if (event[0] != undefined) {
-        this.toggle;
-        this.selected = event[0];
-        this.month =
-          "01-" +
-          this.selected.timestamp.substring(5, 7) +
-          "-" +
-          this.selected.timestamp.substring(0, 4);
+    filterEvent(item) {
+      const event = this.data.find(obj => obj.id === item.id);
+      if (!event) {
+        return;
       }
-    },
-    getEventIndex(day) {
-      var index = this.data.findIndex(obj => obj.date === day);
 
-      return index;
+      this.toggle();
+      this.selected = event;
+    },
+    getEventIndex(date) {
+      return this.data.findIndex(obj => obj.date === date);
     },
     toggle() {
       if (this.$mq == "sm") {
         this.minimize = !this.minimize;
       }
     },
-    selectDate(date) {
-      this.$refs.Calendar.ChooseDate(date);
-    },
     next() {
       if (this.$mq === "md") {
-        this.next_month();
+        this.selected = this.data.find(({ event: { start } }) => (
+          moment(start) > moment(this.selected.event.start).add(1, 'month').startOf('month')
+        )) || this.selected;
       } else {
-        this.next_date();
+        this.selected = this.data.find(({ event: { start } }) => (
+          moment(start) > moment(this.selected.event.start)
+        )) || this.selected;
       }
+      this.selectDate();
     },
     previous() {
       if (this.$mq === "md") {
-        this.previous_month();
+        this.selected = this.dataReverse.find(({ event: { start } }) => (
+          moment(start) < moment(this.selected.event.start).add(-1, 'month').endOf('month')
+        )) || this.selected;
+
+        this.$refs.Calendar.ChooseDate(this.formatDate(this.selected.event.start))
       } else {
-        this.previous_date();
+        this.selected = this.dataReverse.find(({ event: { start } }) => (
+          moment(start) < moment(this.selected.event.start)
+        )) || this.selected;
       }
+      this.selectDate();
     },
-    previous_month() {
-      var select;
-      var index = this.months_data.findIndex(obj => obj === this.month);
+    selectDate() {
+      if (!this.selected) { return }
 
-      if (this.months_data[index - 1]) {
-        select = this.months_data[index - 1];
-      } else {
-        select = this.months_data[this.months_data.length - 1];
-      }
-
-      this.selectDate(select);
-      this.month = select;
+      this.$nextTick(() => (
+        this.$refs.Calendar.ChooseDate(this.formatDate(this.selected.event.start))
+      ))
     },
-    next_month() {
-      var select;
-      var index = this.months_data.findIndex(obj => obj === this.month);
-
-      if (this.months_data[index + 1]) {
-        select = this.months_data[index + 1];
-      } else {
-        select = this.months_data[0];
-      }
-
-      this.selectDate(select);
-      this.month = select;
-    },
-    previous_date() {
-      var index = this.getEventIndex(this.selected.date);
-      var prev_date;
-      if (this.data[index - 1]) {
-        this.selected = this.data[index - 1];
-        prev_date = this.formatDate(this.data[index - 1].timestamp);
-        this.selectDate(prev_date);
-      } else {
-        this.selected = this.data[this.data.length - 1];
-        prev_date = this.formatDate(this.data[this.data.length - 1].timestamp);
-        this.selectDate(prev_date);
-      }
-    },
-    next_date() {
-      var index = this.getEventIndex(this.selected.date);
-      var next_date;
-      if (this.data[index + 1]) {
-        this.selected = this.data[index + 1];
-        next_date = this.formatDate(this.data[index + 1].timestamp);
-        this.selectDate(next_date);
-      } else {
-        this.selected = this.data[0];
-        next_date = this.formatDate(this.data[0].timestamp);
-        this.selectDate(next_date);
-      }
-    },
-    formatDate(value, parse) {
-      function parseNumber(number) {
-        return parseInt(number);
-      }
-
-      var year;
-      var day;
-      var month;
-
-      if (parse == true) {
-        year = parseNumber(value.substring(0, 4));
-        month = parseNumber(value.substring(5, 7));
-        day = parseNumber(value.substring(8, 10));
-      } else {
-        year = value.substring(0, 4);
-        month = value.substring(5, 7);
-        day = value.substring(8, 10);
-      }
-
-      var date = day + "-" + month + "-" + year;
-      return date;
+    formatDate(value) {
+      return moment(value).format("YYYY-MM-DD")
     },
     formatTime(value) {
-      var time = value.substring(11, 16);
-      return time;
+      return moment(value).format("HH:mm")
     },
     getEvents() {
-      axios
-        .get("https://edgeryders.eu/tags/event.json?page=1")
-        .then(({ data }) => {
-          var array = data.topic_list.topics.filter(function(el) {
-            return el.event;
-          });
-          this.raw_data = array;
-
-          var events = array.map(obj => ({
-            date: this.formatDate(obj.event.start, true),
-            time: this.formatTime(obj.event.start),
-            timestamp: obj.event.start,
-            timezone: obj.event.timezone,
-            class: "class2",
-            title: obj.title,
-            excerpt: obj.excerpt,
-            url: "https://edgeryders.eu/t/" + obj.slug,
-            replies: obj.posts_count,
-            image: obj.image_url,
-            created_at: obj.created_at,
-            posted_by: obj.posters[0].user_id,
-            category: obj.category_id
-          }));
-
-          var sorted_events = events.sort((a, b) =>
-            a.timestamp.localeCompare(b.timestamp)
-          );
-
-          this.data = sorted_events;
-
-          function get_month(val) {
-            var date = "01-" + val.substring(5, 7) + "-" + val.substring(0, 4);
-            return date;
-          }
-
-          var months = sorted_events.map(obj => get_month(obj.timestamp));
-          var months_array = new Set(months);
-          this.months_data = [...months_array];
-
-          this.selected = this.data[this.data.length - 1];
-
-          this.$nextTick(() => {
-            var date = this.formatDate(this.selected.timestamp);
-            this.selectDate(date);
-          });
-
-          this.month =
-            "01-" +
-            this.selected.timestamp.substring(5, 7) +
-            "-" +
-            this.selected.timestamp.substring(0, 4);
-        })
-        .catch();
+      axios.get(`${this.baseUrl}/webkit_components/topics.json?serializer=event&tags=event`).then(({ data }) => {
+        this.data = data.sort((a, b) => a.event.start.localeCompare(b.event.start));
+        this.selected = this.data[0]
+        this.selectDate()
+      });
     }
   },
   created() {
     this.getEvents();
   },
   computed: {
-    data_reverse: function() {
+    dataReverse() {
       return this.data.slice().reverse();
+    },
+    dates() {
+      return this.data.map(({ event: { start } }) => moment(start).format('M-d-YYYY'))
     }
   },
   mounted() {
@@ -312,14 +191,10 @@ export default {
   },
   filters: {
     formatDate: function(value) {
-      return moment(String(value)).format("MMMM Do YYYY");
+      return moment(value).format("MMMM Do YYYY");
     },
     formatMonth: function(value) {
-      var day = value.substring(0, 2);
-      var month = value.substring(3, 5);
-      var year = value.substring(6, 10);
-      var date = month + "/" + day + "/" + year;
-      return moment(String(date)).format("MMMM YYYY");
+      return moment(value).format('MMMM YYYY')
     }
   }
 };

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -128,49 +128,75 @@ export default {
     },
     next() {
       if (this.$mq === "md") {
-        this.selected = this.data.find(({ event: { start } }) => (
-          moment(start) > moment(this.selected.event.start).add(1, 'month').startOf('month')
-        )) || this.selected;
+        this.selected =
+          this.data.find(
+            ({ event: { start } }) =>
+              moment(start) >
+              moment(this.selected.event.start)
+                .add(1, "month")
+                .startOf("month")
+          ) || this.selected;
       } else {
-        this.selected = this.data.find(({ event: { start } }) => (
-          moment(start) > moment(this.selected.event.start)
-        )) || this.selected;
+        this.selected =
+          this.data.find(
+            ({ event: { start } }) =>
+              moment(start) > moment(this.selected.event.start)
+          ) || this.selected;
       }
       this.selectDate();
     },
     previous() {
       if (this.$mq === "md") {
-        this.selected = this.dataReverse.find(({ event: { start } }) => (
-          moment(start) < moment(this.selected.event.start).add(-1, 'month').endOf('month')
-        )) || this.selected;
+        this.selected =
+          this.dataReverse.find(
+            ({ event: { start } }) =>
+              moment(start) <
+              moment(this.selected.event.start)
+                .add(-1, "month")
+                .endOf("month")
+          ) || this.selected;
 
-        this.$refs.Calendar.ChooseDate(this.formatDate(this.selected.event.start))
+        this.$refs.Calendar.ChooseDate(
+          this.formatDate(this.selected.event.start)
+        );
       } else {
-        this.selected = this.dataReverse.find(({ event: { start } }) => (
-          moment(start) < moment(this.selected.event.start)
-        )) || this.selected;
+        this.selected =
+          this.dataReverse.find(
+            ({ event: { start } }) =>
+              moment(start) < moment(this.selected.event.start)
+          ) || this.selected;
       }
       this.selectDate();
     },
     selectDate() {
-      if (!this.selected) { return }
+      if (!this.selected) {
+        return;
+      }
 
-      this.$nextTick(() => (
-        this.$refs.Calendar.ChooseDate(this.formatDate(this.selected.event.start))
-      ))
+      this.$nextTick(() =>
+        this.$refs.Calendar.ChooseDate(
+          this.formatDate(this.selected.event.start)
+        )
+      );
     },
     formatDate(value) {
-      return moment(value).format("YYYY-MM-DD")
+      return moment(value).format("YYYY-MM-DD");
     },
     formatTime(value) {
-      return moment(value).format("HH:mm")
+      return moment(value).format("HH:mm");
     },
     getEvents() {
-      axios.get(`${this.baseUrl}/webkit_components/topics.json?serializer=event&tags=event`).then(({ data }) => {
-        this.data = data.sort((a, b) => a.event.start.localeCompare(b.event.start));
-        this.selected = this.data[0]
-        this.selectDate()
-      });
+      axios
+        .get(
+          `${this.baseUrl}/webkit_components/topics.json?serializer=event&tags=event`
+        )
+        .then(({ data }) => {
+          this.data = data.sort((a, b) =>
+            a.event.start.localeCompare(b.event.start)
+          );
+          this.selected = this.data[0];
+          this.selectDate();
+        });
     }
   },
   created() {
@@ -181,7 +207,9 @@ export default {
       return this.data.slice().reverse();
     },
     dates() {
-      return this.data.map(({ event: { start } }) => moment(start).format('M-d-YYYY'))
+      return this.data.map(({ event: { start } }) =>
+        moment(start).format("M-d-YYYY")
+      );
     }
   },
   mounted() {
@@ -194,7 +222,7 @@ export default {
       return moment(value).format("MMMM Do YYYY");
     },
     formatMonth: function(value) {
-      return moment(value).format('MMMM YYYY')
+      return moment(value).format("MMMM YYYY");
     }
   }
 };

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -21,8 +21,8 @@
 export default {
   methods: {
     getLogo() {
-      if (this.data.uploaded_logo !== null) {
-        return "https://edgeryders.eu/" + this.data["uploaded_logo"]["url"];
+      if (this.data.uploaded_logo && this.data.uploaded_logo.url) {
+        return `https://edgeryders.eu/${this.data.uploaded_logo.url}`;
       }
     },
     isCustom(field) {

--- a/src/components/People.vue
+++ b/src/components/People.vue
@@ -24,7 +24,7 @@
     <div class="wrapper md:wrapper-md" v-if="view == 'cards'">
       <Stack
         v-if="$mq == 'sm'"
-        :cards="visibleCards"
+        :cards="users"
         @cardAccepted="handleCardAccepted"
         @cardRejected="handleCardRejected"
         @cardSkipped="handleCardSkipped"
@@ -32,36 +32,36 @@
         :key="componentKey"
       />
 
-      <Row v-else :cards="filtered_users" />
+      <Row v-else :cards="users" />
     </div>
 
     <div
       class="wrapper md:wrapper-md"
-      v-if="filtered_users && (view == 'list') | (view == 'grid')"
+      v-if="users && (view == 'list') | (view == 'grid')"
     >
       <div class="user_grid md:user_grid-md" v-if="view == 'grid'">
         <div
           class="user_avatar md:user_avatar-md"
-          v-for="(item, index) in filtered_users"
-          :key="item.name"
+          v-for="(item, index) in users"
+          :key="item.id"
           @click="setActive(index)"
           :class="{ active: selected === index }"
         >
-          <img :src="item.avatar" />
+          <img :src="item.avatar_url" />
         </div>
       </div>
 
       <div class="user_list md:user_list-md" v-if="view == 'list'">
         <ul>
           <li
-            v-for="(item, index) in filtered_users"
+            v-for="(item, index) in users"
             :key="index"
             @click="setActive(index)"
             :class="{ active: selected === index }"
           >
             <div
               class="user_avatar"
-              :style="{ backgroundImage: 'url(' + item.avatar + ')' }"
+              :style="{ backgroundImage: `url('${item.avatar_url}')` }"
             ></div>
             <p v-if="item.name">{{ item.name }}</p>
             <p v-else>{{ item.username }}</p>
@@ -69,20 +69,20 @@
         </ul>
       </div>
 
-      <div class="w-full px-6" v-if="filtered_users[selected]">
+      <div class="w-full px-6" v-if="users[selected]">
         <a
           class="user_name"
-          :href="'https://edgeryders.eu/u/' + filtered_users[selected].username"
+          :href="'https://edgeryders.eu/u/' + users[selected].username"
         >
           <span class="mr-1">
-            {{ filtered_users[selected].name }}
+            {{ users[selected].name }}
           </span>
-          <span v-if="filtered_users[selected].name" class="font-normal text-lg"
-            >@{{ filtered_users[selected].username }}</span
+          <span v-if="users[selected].name" class="font-normal text-lg"
+            >@{{ users[selected].username }}</span
           >
-          <span v-else> @{{ filtered_users[selected].username }} </span>
+          <span v-else> @{{ users[selected].username }} </span>
         </a>
-        <p class="user_bio">{{ filtered_users[selected].bio }}</p>
+        <p class="user_bio">{{ users[selected].bio_raw }}</p>
       </div>
     </div>
   </div>
@@ -93,18 +93,13 @@ import axios from "axios";
 import Stack from "@/components/Stack.vue";
 import Row from "@/components/Row.vue";
 export default {
-  props: ["users", "custom"],
+  props: ["baseUrl", "custom"],
   data() {
     return {
       selected: 0,
       view: "cards",
-      visibleCards: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
-      allcards: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
       componentKey: 0,
-      bio: null,
-      allusers: null,
-      index: this.users,
-      filtered_users: []
+      users: []
     };
   },
   components: { Stack, Row },
@@ -137,40 +132,18 @@ export default {
       window.console.log("handleCardSkipped");
     },
     removeCardFromDeck() {
-      this.visibleCards.shift();
-      if (this.visibleCards.length == 0) {
-        const newCards = this.filtered_users.slice();
+      this.users.shift();
+      if (this.users.length == 0) {
+        const newCards = this.users.slice();
 
-        this.visibleCards = newCards;
+        this.users = newCards;
         this.forceRerender();
         window.console.log("reset");
       }
     },
     async getActiveUsers() {
-      const array = this.users.map(user => user["username"]);
-
-      const calls = array.map(x =>
-        axios.get(`https://edgeryders.eu/u/${x}.json`).then(resp => {
-          var obj = {
-            username: resp.data.user.username,
-            since: resp.data.user.created_at,
-            name: resp.data.user.name,
-            id: resp.data.user.id,
-            avatar: this.getAvatar(resp.data.user.avatar_template, 200),
-            bio: resp.data.user.bio_raw
-          };
-          return obj;
-        })
-      );
-
-      var result = await Promise.all(calls);
-
-      this.allusers = result;
-      this.filtered_users = result.filter(user => user.bio && user.id !== 4922);
-      this.visibleCards = this.filtered_users.slice();
-    },
-    getAvatar(string, size) {
-      return "https://edgeryders.eu" + string.replace("{size}", size);
+      axios.get(`${this.baseUrl}/webkit_components/users.json`)
+        .then(({ data }) => (this.users = data))
     },
     setActive(index) {
       this.selected = index;

--- a/src/components/People.vue
+++ b/src/components/People.vue
@@ -142,8 +142,9 @@ export default {
       }
     },
     async getActiveUsers() {
-      axios.get(`${this.baseUrl}/webkit_components/users.json`)
-        .then(({ data }) => (this.users = data))
+      axios
+        .get(`${this.baseUrl}/webkit_components/users.json`)
+        .then(({ data }) => (this.users = data));
     },
     setActive(index) {
       this.selected = index;

--- a/src/components/People.vue
+++ b/src/components/People.vue
@@ -104,7 +104,7 @@ export default {
       bio: null,
       allusers: null,
       index: this.users,
-      filtered_users: false
+      filtered_users: []
     };
   },
   components: { Stack, Row },

--- a/src/components/Row.vue
+++ b/src/components/Row.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="card_row" ref="content" v-dragscroll.x="true">
-    <div class="card" v-for="item in cards" :key="item">
+    <div class="card" v-for="item in cards" :key="item.id">
       <div class="card_title">
         <div
           class="avatar"
-          :style="{ backgroundImage: 'url(' + item.avatar + ')' }"
+          :style="{ backgroundImage: `url('${item.avatar_url}')` }"
         ></div>
         <div class="card_name">
           <h3>
             <span v-if="item.name">{{ item.name }}</span
             ><span v-else>{{ item.username }}</span>
           </h3>
-          <p>Active since {{ item.since | formatDate }}</p>
+          <p>Active since {{ item.created_at | formatDate }}</p>
         </div>
       </div>
-      <div class="card_excerpt" v-html="item.bio"></div>
+      <div class="card_excerpt" v-html="item.bio_raw"></div>
       <div class="card_footer">Connect with @{{ item.username }}</div>
     </div>
   </div>
@@ -42,8 +42,8 @@ export default {
     }
   },
   filters: {
-    formatDate: function(value) {
-      return moment(String(value)).format("MM/DD/YY");
+    formatDate: function(date) {
+      return moment(date).format("MM/DD/YY");
     }
   }
 };

--- a/src/components/Topics.vue
+++ b/src/components/Topics.vue
@@ -4,7 +4,7 @@
 
     <swiper :options="sliderOptions" ref="mySwiper" class="section_slider">
       <!-- slides -->
-      <swiper-slide v-for="item in data" :key="item.created_at">
+      <swiper-slide v-for="item in topics" :key="item.created_at">
         <div class="slide">
           <div
             v-if="item.image_url"
@@ -37,7 +37,7 @@ import moment from "moment";
 import "swiper/dist/css/swiper.css";
 
 export default {
-  props: ["data", "custom"],
+  props: ["topics", "custom"],
   data() {
     return {
       selected: 0,
@@ -76,8 +76,8 @@ export default {
     }
   },
   filters: {
-    formatDate: function(value) {
-      return moment(String(value)).format("dddd MMMM Do YYYY");
+    formatDate: function(date) {
+      return moment(date).format("dddd MMMM Do YYYY");
     }
   },
   components: {

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -1,5 +1,5 @@
 {
-  "category": "1",
+  "category": "237",
   "sections": [
     {
       "type": "hero"

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -1,5 +1,5 @@
 {
-  "category": "237",
+  "category": "1",
   "sections": [
     {
       "type": "hero"

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl" :"https://edgeryders.eu",
   "category": "237",
   "sections": [
     {

--- a/src/main.js
+++ b/src/main.js
@@ -6,10 +6,10 @@ import VueScrollactive from "vue-scrollactive";
 import VueDragscroll from "vue-dragscroll";
 
 Vue.use(VueMq, {
-	breakpoints: {
-		sm: 450,
-		md: Infinity
-	}
+  breakpoints: {
+    sm: 450,
+    md: Infinity
+  }
 });
 
 Vue.use(VueScrollactive);


### PR DESCRIPTION
Alright, I've hooked up the `Events` and `People` components to use their respective endpoints (it's possible we'll need some future tweaking on these depending on what the exact use cases are), as well as loading the category in question.

This has facilitated a minor refactor of the `People` component, and a more thorough refactor of the `Events` component, so let me know of anything that seems missing from those two and I'm happy to patch them up.

I've also pulled the `baseUrl` out into the config, to allow for easier swapping out of hosts for local development (I've tested this against a local Discourse instance since the CORS policy on `edgeryders.eu` won't let me query it directly from localhost.)