### PR TITLE
Port edgeryder-form component over into signup form

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Styling uses Tailwind utilities, [read more here](https://tailwindcss.com/docs/a
 -   Topics
 -   Events
 -   Custom
+-   Form
 
 ## Custom Components
 
@@ -49,6 +50,12 @@ npm run build
 ### Customize configuration
 
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+#### Form configuration
+
+The form component is ported directly from the [edgeryders form builder](https://github.com/edgeryders/edgeryders-form), and most configuration noted on that repository will work within the `data/config.json` here.
+
+(NB that you'll need a `.env.<environment>` file with the values noted under [Installation](https://github.com/edgeryders/edgeryders-form#2-installation) in order for the form to submit successfully.)
 
 ## Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8506,6 +8506,11 @@
         "no-case": "^2.2.0"
       }
     },
+    "parameterize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parameterize/-/parameterize-1.0.0.tgz",
+      "integrity": "sha512-7i+fCXWfdt7fEs9xMeQHC5e7G1OXX8J5JtfuzhgnqAZU1i6e2qX3aigQ2OH5uongdqmKz/xgMqfY7jtTZDTBYw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10313,6 +10318,11 @@
           }
         }
       }
+    },
+    "secure-random-string": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/secure-random-string/-/secure-random-string-1.1.2.tgz",
+      "integrity": "sha512-o5aaoY4mEh209vOmt4wkUMF/uxGJV87ImeQdv1BnVQ7TOjemUiT6xgED3VpHTGz2AlmMfqBxS8C+UMZAxSOATA=="
     },
     "select-hose": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "core-js": "^3.4.4",
     "interact.js": "^1.2.8",
     "moment": "^2.24.0",
+    "parameterize": "^1.0.0",
+    "secure-random-string": "^1.1.2",
     "swing": "^3.1.4",
     "v-calendar": "^1.0.0-beta.23",
     "vue": "^2.6.10",

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
       <People v-if="section.type == 'people'" :baseUrl="data.baseUrl" :custom="section" />
       <Edgeryders v-if="section.type == 'edgeryders'" :custom="section"
       />
+      <Form v-if="section.type == 'form'" :baseUrl="data.baseUrl" :custom="section" />
     </div>
 
     <Terms />
@@ -29,6 +30,7 @@ import Topics from "@/components/Topics.vue";
 import People from "@/components/People.vue";
 import Users from "@/components/Users.vue";
 import Edgeryders from "@/components/Edgeryders.vue";
+import Form from "@/components/Form.vue";
 import Terms from "@/components/Terms.vue";
 
 import axios from "axios";
@@ -52,6 +54,7 @@ export default {
     Nav,
     Custom,
     Edgeryders,
+    Form,
     Terms
   },
   created() {

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="section section-md" id="form">
+    <div class="content">
+      <Title class="even" v-bind="slide" />
+      <div class="even">
+        <Body v-bind="slide" :response="response" :next="next" />
+        <Fields v-bind="slide" :response="response" :next="next" />
+        <Error v-for="error in errors" :key="error" :error="error" />
+      </div>
+    </div>
+    <Progress :index="slide.index" :maxIndex="maxIndex" mobile />
+    <Navigation :back="back" :next="next" :maxIndex="maxIndex" v-bind="slide" />
+  </div>
+</template>
+
+<script>
+import Title from "./form/Title.vue";
+import Body from "./form/Body.vue";
+import Fields from "./form/Fields.vue";
+import Error from "./form/Error.vue";
+import Progress from "./form/Progress.vue";
+import Navigation from "./form/Navigation.vue";
+import submit from "../helpers/discourse";
+
+export default {
+  props: ["custom", "baseUrl"],
+  data() {
+    return { form: {}, currentIndex: 0, errors: [] };
+  },
+  created() {
+    this.slides
+      .filter(s => s.index)
+      .forEach(({ index, body, settings, fields }) => {
+        this.$set(this.form, index, { body, settings });
+        fields.forEach(({ name, settings = {} }) => {
+          this.$set(this.form[index], name, { settings });
+          this.$set(this.form[index][name], "value", "");
+          this.$set(this.form[index][name], "error", "");
+        });
+      });
+
+    document.addEventListener("keyup", ({ target: { tagName }, keyCode }) => {
+      if (["INPUT", "TEXTAREA"].includes(tagName)) {
+        return;
+      }
+
+      switch (keyCode) {
+        case 37:
+          return this.back ? this.back() : null;
+        case 39:
+          return this.next ? this.next() : null;
+      }
+    });
+  },
+  computed: {
+    slides() {
+      return this.custom.slides.map(slide => Object.assign({}, this.custom.slideDefaults, slide))
+    },
+    slide() {
+      return this.slides[this.currentIndex];
+    },
+    response() {
+      return this.form[this.slide.index] || {};
+    },
+    maxIndex() {
+      return Math.max(...this.slides.map(slide => slide.index || 0));
+    },
+    back() {
+      return this.currentIndex > 0 ? this.retreat : null;
+    },
+    next() {
+      return () =>
+        this.slide.submit
+          ? this.validate() && submit(this.form).then(this.proceed, this.fail)
+          : this.validate() && this.proceed();
+    }
+  },
+  methods: {
+    retreat() {
+      this.currentIndex -= 1;
+    },
+    proceed() {
+      this.currentIndex += 1;
+    },
+    fail(errors) {
+      this.errors = errors;
+    },
+    validate() {
+      this.errors = [];
+      const { index, fields } = this.slide;
+      if (!index || !fields) {
+        return true;
+      }
+
+      fields.forEach(
+        ({ name, required, error }) =>
+          (this.response[name].error =
+            required && !this.response[name].value ? error : null)
+      );
+
+      return Object.values(this.response).every(({ error }) => !error);
+    }
+  },
+  components: {
+    Title,
+    Body,
+    Fields,
+    Error,
+    Progress,
+    Navigation
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.content {
+  display: flex;
+}
+
+.even {
+  flex-basis: 50%;
+  margin-right: 2rem;
+}
+
+@media (max-width: 768px) {
+  .content {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/components/form/Body.vue
+++ b/src/components/form/Body.vue
@@ -1,0 +1,15 @@
+<template>
+  <p class="body" v-if="body" v-html="body" />
+</template>
+
+<script>
+export default {
+  props: { body: String }
+};
+</script>
+
+<style scoped>
+.body {
+  margin: 0 0 1rem 0;
+}
+</style>

--- a/src/components/form/Error.vue
+++ b/src/components/form/Error.vue
@@ -1,0 +1,17 @@
+<template>
+  <p v-if="error" class="error">{{ error }}</p>
+</template>
+
+<script>
+export default {
+  props: { error: String }
+};
+</script>
+
+<style scoped lang="scss">
+@import '../../assets/colors.scss';
+
+.error {
+  color: $c-red-50;
+}
+</style>

--- a/src/components/form/Field.vue
+++ b/src/components/form/Field.vue
@@ -1,0 +1,120 @@
+<template>
+  <li :class="klass">
+    <textarea
+      v-if="isTextarea"
+      class="textarea"
+      :ref="name"
+      :placeholder="placeholder"
+      v-model="response[name].value"
+      v-on:keyup.meta.enter="next"
+      v-on:keyup.ctrl.enter="next"
+    />
+    <label class="label" v-else>
+      <input
+        :ref="name"
+        :id="name"
+        class="input"
+        :placeholder="placeholder"
+        :type="type"
+        v-model="response[name].value"
+        v-on:keyup.enter="next"
+      />
+      <span v-if="isCheckbox">{{ placeholder }}</span>
+    </label>
+    <Error :error="error" />
+  </li>
+</template>
+
+<script>
+import Error from "./Error";
+
+export default {
+  props: {
+    response: Object,
+    type: String,
+    name: String,
+    placeholder: String,
+    half: Boolean,
+    autofocus: Boolean,
+    next: Function
+  },
+  mounted() {
+    this.handleFocus();
+  },
+  updated() {
+    this.handleFocus();
+  },
+  computed: {
+    error() {
+      return this.response[this.name].error;
+    },
+    klass() {
+      return `${this.half ? "half" : "full"} ${this.type}`;
+    },
+    isTextarea() {
+      return this.type === "textarea";
+    },
+    isCheckbox() {
+      return this.type === "checkbox";
+    },
+    textarea() {
+      return this.$refs[this.name];
+    },
+    isFocused() {
+      return document.activeElement == this.textarea;
+    }
+  },
+  methods: {
+    handleFocus() {
+      if (this.autofocus && !this.isFocused) {
+        this.textarea.focus();
+      }
+    }
+  },
+  components: { Error }
+};
+</script>
+
+<style lang="scss" scoped>
+.half {
+  float: left;
+  width: 50%;
+
+  &:nth-child(2) .input {
+    border-left: 1px solid;
+  }
+}
+
+.textarea {
+  padding: 0.4rem;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 16px;
+  border-radius: 2px;
+  min-height: 10rem;
+}
+
+.input {
+  width: 100%;
+  padding: 1rem 0.5rem;
+  border: 0px solid black;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  font-size: 14px;
+  margin-bottom: -1px;
+}
+
+.checkbox {
+  margin: 2rem 0;
+  display: block;
+
+  .label {
+    display: flex;
+  }
+
+  .input {
+    width: auto;
+    margin-right: 1rem;
+  }
+}
+</style>

--- a/src/components/form/Fields.vue
+++ b/src/components/form/Fields.vue
@@ -1,0 +1,20 @@
+<template>
+  <ul v-if="fields">
+    <Field
+      v-for="field in fields"
+      :key="field.name"
+      :response="response"
+      :next="next"
+      v-bind="field"
+    />
+  </ul>
+</template>
+
+<script>
+import Field from "./Field";
+
+export default {
+  props: { response: Object, fields: Array, next: Function },
+  components: { Field }
+};
+</script>

--- a/src/components/form/Navigation.vue
+++ b/src/components/form/Navigation.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="navigation flex">
+    <div v-if="!allowBack" />
+    <button
+      :title="backTitle"
+      class="text-white bg-primary border border-primary text-xm font-semibold rounded-lg px-4 py-3 mt-6 leading-normal"
+      v-if="allowBack"
+      v-on:click="back"
+    >
+      {{ backText }}
+    </button>
+    <Progress :index="index" :maxIndex="maxIndex" />
+    <button
+      :title="nextTitle"
+      class="text-white bg-primary border border-primary text-xm font-semibold rounded-lg px-4 py-3 mt-6 leading-normal"
+      v-if="allowNext"
+      v-on:click="next"
+    >
+      {{ nextText }}
+    </button>
+  </div>
+</template>
+
+<script>
+import Progress from "./Progress";
+
+export default {
+  props: {
+    back: Function,
+    backText: String,
+    backTitle: String,
+    next: Function,
+    nextText: String,
+    nextTitle: String,
+    nextUrl: String,
+    index: Number,
+    maxIndex: Number
+  },
+  computed: {
+    allowBack() {
+      return this.back && this.backText;
+    },
+    allowNext() {
+      return this.next && this.nextText;
+    }
+  },
+  components: { Progress }
+};
+</script>
+
+<style scoped>
+.flex {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/src/components/form/Progress.vue
+++ b/src/components/form/Progress.vue
@@ -1,0 +1,73 @@
+<template>
+  <ul :class="className" v-if="display">
+    <li v-for="dot in dots" :key="dot">
+      <div class="dot complete" v-if="dot < index"></div>
+      <div class="dot incomplete" v-else></div>
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  props: {
+    index: Number,
+    maxIndex: Number,
+    mobile: Boolean
+  },
+  computed: {
+    className() {
+      return this.mobile ? "dots mobile" : "dots";
+    },
+    display() {
+      return this.index && this.maxIndex > 1;
+    },
+    dots() {
+      return [...Array(this.maxIndex).keys()];
+    }
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.dots-mobile {
+  display: none;
+}
+
+.dots {
+  display: flex;
+
+  &.mobile {
+    display: none;
+  }
+}
+
+.dot {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  margin: 0 0.5rem;
+}
+
+.completed {
+  background: black;
+}
+
+@media (max-width: 768px) {
+  .dots {
+    display: none;
+
+    &.mobile {
+      display: flex;
+      padding: 2rem 1rem;
+      flex-grow: 1;
+      justify-content: center;
+      align-items: flex-end;
+    }
+  }
+
+  .dot {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+</style>

--- a/src/components/form/Title.vue
+++ b/src/components/form/Title.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <h1 class="title" v-if="title">{{ displayTitle }}</h1>
+    <h3 class="subtitle" v-if="subtitle">{{ subtitle }}</h3>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    index: Number,
+    title: String,
+    subtitle: String
+  },
+  computed: {
+    displayTitle() {
+      return this.title.replace(/{{index}}/, this.index);
+    }
+  }
+};
+</script>

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -79,6 +79,73 @@
     },
     {
       "type": "terms"
+    },
+    {
+      "type": "form",
+      "slideDefaults": {
+        "title": "Q{{index}}",
+        "backText": "BACK",
+        "nextText": "NEXT",
+        "backTitle": "Go back",
+        "nextTitle": "Continue",
+        "fields": [{
+          "name": "message",
+          "type": "textarea",
+          "placeholder": "write here...",
+          "required": true,
+          "autofocus": true,
+          "error": "Please write a response!"
+        }],
+        "diagram": {},
+        "settings": { "omitFields": true }
+      },
+      "slides": [{
+        "index": 1,
+        "title": "Join the edgeryders!",
+        "nextTitle": "SIGN UP",
+        "body": "This will create an account for you",
+        "fields": [{
+          "name": "name",
+          "type": "text",
+          "placeholder": "Name/nickname",
+          "half": true,
+          "required": true,
+          "autofocus": true,
+          "error": "Please enter your name"
+        }, {
+          "name": "age",
+          "type": "integer",
+          "placeholder": "Age (optional)",
+          "half": true
+        }, {
+          "name": "email",
+          "type": "email",
+          "placeholder": "E-mail",
+          "required": true,
+          "error": "Please enter your email address",
+          "settings": { "omit": true }
+        }, {
+          "name": "consent",
+          "type": "checkbox",
+          "placeholder": "I consent to the terms and conditions",
+          "required": true,
+          "error": "Please consent to the terms and conditions",
+          "settings": { "omit": true }
+        }],
+        "nextText": "SEND",
+        "submit": true,
+        "settings": { "omitBody": true }
+      }, {
+        "title": "Well done!",
+        "body": "Thank you for taking the time to create an account on Edgeryders!",
+        "fields": []
+      }],
+      "errorMessages": {
+        "networkError": "Sorry, we were unable to store your response due to a network connectivity issue. Please try clicking on \"Send\" again.",
+        "username": "It seems somebody has already chosen your preferred username / nickname. Please enter a different one and click again on \"Send\".",
+        "email": "It seems you already have an account on our forum using this e-mail address, or have entered an invalid address. Please choose a different e-mail address and click again on \"Send\".",
+        "default": "Sorry, we were unable to store your response due to an unknown error. Please try clicking on \"Send\" again."
+      }
     }
   ]
 }

--- a/src/helpers/discourse.js
+++ b/src/helpers/discourse.js
@@ -1,0 +1,90 @@
+import generatePassword from "secure-random-string";
+import parameterize from "parameterize";
+
+const createUser = (form, authKey, errorMessages) =>
+  fetch(
+    `${process.env.VUE_APP_DISCOURSE_USER_URL}?${Object.entries({
+      accepted_gtc: true,
+      accepted_privacy_policy: true,
+      edgeryders_research_content: true,
+      requested_api_keys: [process.env.VUE_APP_DISCOURSE_DOMAIN],
+      auth_key: authKey,
+      email: formField(form, "email"),
+      username: generateUsername(form),
+      password: generatePassword({ length: 15 })
+    })
+      .map(pair => pair.map(encodeURIComponent).join("="))
+      .join("&")}`
+  ).then(
+    response => handleResponse(response, errorMessages),
+    response => handleNetworkError(response, errorMessages)
+  );
+
+const createTopic = (form, apiKey, errorMessages) =>
+  fetch(process.env.VUE_APP_DISCOURSE_TOPIC_URL, {
+    method: "post",
+    headers: { "Api-Key": apiKey, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: `Rethinking retirement - response by ${formField(form, "name")}`,
+      raw: generateResponse(form),
+      category: process.env.VUE_APP_DISCOURSE_CATEGORY
+    })
+  }).then(
+    response => handleResponse(response, errorMessages),
+    response => handleNetworkError(response, errorMessages)
+  );
+
+const handleResponse = (response, errorMessages) =>
+  response.ok
+    ? response.json()
+    : response
+        .json()
+        .then(({ errors }) =>
+          Promise.reject(
+            Object.keys(errors).map(
+              key => errorMessages[key] || errorMessages.default
+            )
+          )
+        );
+
+const handleNetworkError = (response, errorMessages) =>
+  Promise.reject([errorMessages.networkError]);
+
+const formField = (form, field) =>
+  Object.values(form)
+    .map(f => (f[field] || {}).value)
+    .filter(value => value)
+    .join("");
+
+const generateUsername = form =>
+  `${parameterize(formField(form, "name"), 20, "_")}_${Math.ceil(
+    Math.random() * 100
+  )}`;
+
+const generateResponse = form =>
+  Object.values(form)
+    .map(({ body, settings: { omitBody, omitFields }, ...fields }) => [
+      omitBody ? "" : `**${body}**`,
+      Object.entries(fields)
+        .filter(
+          ([
+            ,
+            {
+              settings: { omit }
+            }
+          ]) => !omit
+        )
+        .map(([field, { value }]) =>
+          [omitFields ? "" : `**${field}:** `, value].join("")
+        )
+        .join("\n")
+    ])
+    .flat()
+    .join("\n\n");
+
+export default (form, errorMessages) =>
+  createUser(
+    form,
+    process.env.VUE_APP_DISCOURSE_AUTH_KEY,
+    errorMessages
+  ).then(json => createTopic(form, json.api_keys[0].key, errorMessages));


### PR DESCRIPTION
This takes the code written already for https://github.com/edgeryders/edgeryders-form and ports it into a web component, which takes a `baseUrl` and `custom` prop (derived from `config.json`) like the rest of the components.

The vast majority of the configuration available for that form builder remains in this repo as well, including multi-page forms and customizable form fields, although the majority of use cases will be a more simple signup form.

@owengot I've attempted to strip as much css out of this as possible to allow for Tailwind to do its thing here, but it could still use some styling love.

I've left in the bit where it posts as a topic to a given category for now; next step will be to allow the configuration to specify skipping that part and just make a user account for you on `edgeryders.eu`