### PR TITLE
Minimize API queries

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,8 +41,7 @@ export default {
     return {
       data,
       category: { users: [] },
-      categories: [],
-      topics: []
+      categories: []
     };
   },
   components: {
@@ -71,11 +70,6 @@ export default {
       this.category = data.find(
         ({ id }) => id === parseInt(this.data.category)
       );
-      axios
-        .get(
-          `${this.data.baseUrl}/webkit_components/topics.json?categories=${this.category.slug}`
-        )
-        .then(({ data }) => (this.topics = data));
     },
     getCategoryMetadata(id) {
       return this.categories.find(category => category.id === id) || {};

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -169,49 +169,20 @@ export default {
       }
        this.selectEvent(prev, false);
     },
-    sortEvents(array) {
-      var events = array.map( x => {
-        x.date = this.formatDate(x.event.start);
-        x.class = "marked";
-        return x
-      })
-
-      var sorted_events = events.sort((a, b) =>
-        a.event.start.localeCompare(b.event.start)
-      );
-
-      this.data = sorted_events;
-      this.selectEvent(this.dataReverse[0]);
-    },
-    async getEvents(tag) {
-      let count = 0;
-      let total = 1;
-
-      let from = 0;
-      let per = 50;
-
-      var eventArray = [];
-
-      while (count < total) {
-        count++;
-        let response = await axios.get(
-          `${this.baseUrl}/webkit_components/topics.json?serializer=event&tags=${tag}&from=${from}&per=${per}`
-        );
-        if (response.data.length) {
-          total++;
-          from = per * count;
-          var array = response.data.filter(function(item) {
-            return item.event;
-          });
-          var newArray = eventArray.concat(array);
-          eventArray = newArray;
-        } else {
-          break;
-        }
-      }
-      if (total == count) {
-        this.sortEvents(eventArray);
-      }
+    getEvents(tag) {
+      axios.get(
+        `${this.baseUrl}/webkit_components/topics.json?serializer=event&tags=${tag}&per=500`
+      ).then(({ data }) => {
+        this.data = data
+          .filter(({ event }) => event)
+          .map(event => ({
+            ...event,
+            date: this.formatDate(event.event.start),
+            class: "marked"
+          }))
+          .sort((a, b) => a.event.start.localeCompare(b.event.start));
+        this.selectEvent(this.dataReverse[0]);
+      });
     },
     formatDate(value) {
       return moment(value).format("D-M-YYYY");

--- a/src/components/People.vue
+++ b/src/components/People.vue
@@ -76,26 +76,10 @@ export default {
         return username[0];
       }
     },
-    async getPeople(tag) {
-      let count = 0; let total = 1;
-      let from = 0; let per = 25;
-      var peopleArray = [];
-
-      while (count < total) {
-        count++;
-        let response = await axios.get(
-          `${this.baseUrl}/webkit_components/topics.json?tags=${tag}&from=${from}&per=${per}`
-        );
-        if (response.data.length) {
-          total++; from = per * count;
-          peopleArray = peopleArray.concat(response.data);
-        } else {
-          break;
-        }
-      }
-      if (total == count) {
-        this.people = peopleArray;
-      }
+    getPeople(tag) {
+      axios.get(
+        `${this.baseUrl}/webkit_components/topics.json?tags=${tag}&per=500`
+      ).then(({ data }) => this.people = data);
     }
   },
   mounted: function() {

--- a/src/components/Topics.vue
+++ b/src/components/Topics.vue
@@ -48,26 +48,10 @@ export default {
     }
   },
   methods: {
-    async getTopics(value, filter) {
-      let count = 0; let total = 1;
-      let from = 0; let per = 25;
-      var topicsArray = [];
-
-      while (count < total) {
-        count++;
-        let response = await axios.get(
-          `${this.baseUrl}/webkit_components/topics.json?${filter}=${value}&from=${from}&per=${per}`
-        );
-        if (response.data.length) {
-          total++; from = per * count;
-          topicsArray = topicsArray.concat(response.data);
-        } else {
-          break;
-        }
-      }
-      if (total == count) {
-        this.topics = topicsArray;
-      }
+    getTopics(value, filter) {
+      axios.get(
+        `${this.baseUrl}/webkit_components/topics.json?${filter}=${value}&per=500`
+      ).then(({ data }) => this.topics = data);
     }
   }
 };

--- a/src/components/Users.vue
+++ b/src/components/Users.vue
@@ -131,35 +131,13 @@ export default {
         this.forceRerender();
       }
     },
-    async getUsers() {
-      let count = 0;
-      let total = 3;
-
-      let from = 0;
-      let per = 50;
-
-      var usersArray = [];
-
-      while (count < total) {
-        count++;
-        let response = await axios.get(
-          `${this.baseUrl}/webkit_components/users.json?from=${from}&per=${per}`
-        );
-        if (response.data.length) {
-          from = per * count;
-          var array = response.data.filter(function(item) {
-            return item.bio_raw;
-          });
-          var newArray = usersArray.concat(array);
-          usersArray = newArray;
-        } else {
-          break;
-        }
-      }
-      if (total == count) {
-        this.allusers = usersArray;
-        this.visibleCards = this.allusers.slice();
-      }
+    getUsers() {
+      axios.get(
+        `${this.baseUrl}/webkit_components/users.json?per=500`
+      ).then(({ data }) => {
+        this.allusers = data.filter(({ bio_raw }) => bio_raw);
+        this.visibleCards = this.users;
+      });
     },
     setActive(index) {
       this.selected = index;


### PR DESCRIPTION
Currently we're paginating API queries, which is making the page take much longer to load.

There's still some improvements we can make on the backend to speed this up more, but this is a fairly easy win to bring the initial page load time down.

Before:
![Captura de pantalla 2020-02-19 a la(s) 11 33 02 a  m](https://user-images.githubusercontent.com/750477/74783918-a3701a00-530b-11ea-9368-4870bc4b0dcf.png)

After:
![Captura de pantalla 2020-02-19 a la(s) 11 32 29 a  m](https://user-images.githubusercontent.com/750477/74783928-a79c3780-530b-11ea-9c7a-3fc02ec53dd0.png)
