### PR TITLE
Use full cooked value for People and Stories

### DIFF
--- a/src/components/People.vue
+++ b/src/components/People.vue
@@ -23,21 +23,7 @@
           {{ people[selected].title }} <span>{{ getUser(people[selected].excerpt) }}</span>
         </a>
 
-        <div class="bio" v-if="getExcerpt(people[selected].excerpt).length > 1">
-          <h2 class="font-bold mb-4">
-            {{ getExcerpt(people[selected].excerpt)[0] }}
-          </h2>
-          <p>
-            {{ getExcerpt(people[selected].excerpt)[1] }}
-          </p>
-          <p>
-            {{ getExcerpt(people[selected].excerpt)[2] }}
-          </p>
-        </div>
-        <div class="user_bio" v-else>
-          {{ getExcerpt(people[selected].excerpt)[0] }}
-        </div>
-
+        <div class="bio" v-html="people[selected].cooked" />
       </div>
     </div>
   </div>
@@ -57,17 +43,6 @@ export default {
     setActive(index) {
       this.selected = index;
     },
-    getExcerpt(excerpt) {
-      return excerpt
-        .toString()
-        .replace(/(@[^\s]*(?=<\/a>))/g, "")
-        .replace(/(<([^>]+)>)/gi, "")
-        .replace(/\s*\[.*?\]\s*/g, "")
-        .replace("&hellip;", "...")
-        .replace("&amp", "&")
-        .split(/\n/g)
-        .filter(v => v.length > 3);
-    },
     getUser(excerpt) {
       var username = excerpt.match(/(@[^\s]*(?=<\/a>))/g);
       if (username == null) {
@@ -78,7 +53,7 @@ export default {
     },
     getPeople(tag) {
       axios.get(
-        `${this.baseUrl}/webkit_components/topics.json?tags=${tag}&per=500`
+        `${this.baseUrl}/webkit_components/topics.json?serializer=organizer&tags=${tag}&per=500`
       ).then(({ data }) => this.people = data);
     }
   },
@@ -101,5 +76,9 @@ export default {
   &.active {
     border: 4px solid black;
   }
+}
+
+.user_grid {
+  align-content: flex-start;
 }
 </style>

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -30,7 +30,7 @@
           </div>
           <Profile class="ml-3" v-if="show('author')" :data="currentSlide.author" />
         </div>
-        <div v-html="currentSlide.excerpt" class="excerpt md:excerpt-md"></div>
+        <div v-html="cooked || currentSlide.excerpt" class="excerpt md:excerpt-md"></div>
       </div>
     </transition-group>
 
@@ -99,6 +99,14 @@ export default {
   computed: {
     currentSlide: function() {
       return this.slides[Math.abs(this.currentIndex) % this.slides.length];
+    },
+    cooked: function() {
+      if (!this.currentSlide) { return ""; }
+
+      return this.currentSlide.cooked.replace(
+        'class="lightbox-wrapper"',
+        'class="lightbox-wrapper hidden"'
+      )
     }
   },
   created() {
@@ -140,6 +148,10 @@ export default {
   left: 0;
   bottom: 0;
   right:0;
+}
+
+.slider .excerpt {
+  overflow: auto;
 }
 
 .slider .slide .item_title {

--- a/src/components/Topics.vue
+++ b/src/components/Topics.vue
@@ -51,9 +51,9 @@ export default {
   methods: {
     getTopics(value, filter) {
       axios.get(
-        `${this.baseUrl}/webkit_components/topics.json?${filter}=${value}&per=500`
+        `${this.baseUrl}/webkit_components/topics.json?${filter}=${value}&per=500&serializer=organizer`
       ).then(({ data }) => {
-        this.topics = data; 
+        this.topics = data;
         if (this.custom.sort) {
           this.sortBy(data, this.custom.sort_by.property, this.custom.sort_by.order)
         }
@@ -65,7 +65,7 @@ export default {
         ord_val = 1;
       };
       var sorted = data.sort((a,b) => (a[value] > b[value]) ? ord_val : ((b[value] > a[value]) ? -ord_val : 0));
-      this.data = sorted; 
+      this.data = sorted;
     }
   }
 };


### PR DESCRIPTION
This displays the full cooked value for user bios for the `People` component, and full topic values for the `Stories` component:

`<People />`:
![Captura de pantalla 2020-02-26 a la(s) 6 51 26 p  m](https://user-images.githubusercontent.com/750477/75315986-0abc3a00-58c9-11ea-98ca-0fd41e163111.png)

`<Stories />`:
![Captura de pantalla 2020-02-26 a la(s) 7 29 52 p  m](https://user-images.githubusercontent.com/750477/75318089-52919000-58ce-11ea-9d2f-49b0a513c36d.png)


@owengot FYI there are a few bios on the current edgeryders site which for whatever reason aren't loading their bio image properly, which is collapsing the columns:
![Captura de pantalla 2020-02-26 a la(s) 6 57 01 p  m](https://user-images.githubusercontent.com/750477/75316274-bebdc500-58c9-11ea-98cf-c9ac7aed043c.png)
