### PR TITLE
Fix form submission for registration

### DIFF
--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -35,6 +35,7 @@ export default {
     return { form: {}, currentIndex: 0, errors: [] };
   },
   created() {
+    this.$set(this.form, 'settings', { createTopic: this.custom.settings });
     this.slides
       .filter(s => s.index)
       .forEach(({ index, body, settings, fields }) => {

--- a/src/data/config.json
+++ b/src/data/config.json
@@ -233,6 +233,9 @@
       "title": "Join us",
       "id": "join",
       "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      "settings": {
+        "createTopic": false
+      },
       "slideDefaults": {
         "title": "Q{{index}}",
         "backText": "BACK",

--- a/src/helpers/discourse.js
+++ b/src/helpers/discourse.js
@@ -87,4 +87,8 @@ export default (form, errorMessages) =>
     form,
     process.env.VUE_APP_DISCOURSE_AUTH_KEY,
     errorMessages
-  ).then(json => createTopic(form, json.api_keys[0].key, errorMessages));
+  ).then(json => (
+    form.settings.createTopic
+      ? createTopic(form, json.api_keys[0].key, errorMessages)
+      : json
+  ))


### PR DESCRIPTION
This adds the concept of 'settings' to a form, which will allow us to control which web requests are executed as a result of form submission.

The current example should create a user, without attempting to create a follow-up topic.